### PR TITLE
Updates to reflect the changes to extension listings on the extension registry in https://github.com/sourcegraph/sourcegraph/pull/1612:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "python",
-  "title": "Python",
-  "description": "Python code intelligence (using the Python language server)",
+  "description": "Python code intelligence",
   "publisher": "sourcegraph",
   "activationEvents": [
     "onLanguage:python"
@@ -10,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/sourcegraph/sourcegraph-python"
   },
+  "wip": true,
+  "categories": ["Programming languages"],
+  "tags": ["python", "language-server"],
   "contributes": {
     "configuration": {
       "title": "Python settings",


### PR DESCRIPTION
- Extensions can have tags and categories.
- Extensions can specify they are WIP in package.json with `"wip": true`.

Also:

- Extensions no longer have titles. The extension ID, `sourcegraph/python`, and the extension description are the only things shown now. (As of https://github.com/sourcegraph/sourcegraph/pull/1613.)
- The extension description can/should be shorter now that it's shown on 1 line and there is no title.