### PR TITLE
chore: replace broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This extension provides Python code intelligence on Sourcegraph. Ensure this extension is enabled and then try it on some examples:
 
 -   Tensorflow: [tensorflow_ranking/examples/tf_ranking_libsvm.py](https://sourcegraph.com/github.com/tensorflow/ranking@931e4e18d68612d0b29dc3c81994acdd4b6ab743/-/blob/tensorflow_ranking/examples/tf_ranking_libsvm.py#L294:27&tab=references)
--   Flask: [flask/views.py](https://sourcegraph.com/github.com/pallets/flask/-/blob/flask/views.py)
+-   Flask: [flask/views.py](https://sourcegraph.com/github.com/pallets/flask/-/blob/src/flask/views.py)
 -   Zulip: [corporate/lib/stripe.py](https://sourcegraph.com/github.com/zulip/zulip/-/blob/corporate/lib/stripe.py)
 -   Trivial sample: [pkg0/m0.py](http://sourcegraph.com/github.com/sgtest/python-sample-0/-/blob/pkg0/m0.py)
 


### PR DESCRIPTION
### Test plan

A test plan is not required because the change is only documentation.


### Problem

The flask link is broken

![Captura de pantalla 2023-10-03 a la(s) 16 24 32](https://github.com/sourcegraph/sourcegraph-python/assets/18150705/da8f7a3a-30c0-4c60-b66e-64b0f80ba145)
![Captura de pantalla 2023-10-03 a la(s) 16 25 22](https://github.com/sourcegraph/sourcegraph-python/assets/18150705/d3bc952a-87d5-4585-bc65-1713da63f0aa)

### Solution

Replace flask link to a new one

![Captura de pantalla 2023-10-03 a la(s) 16 25 45](https://github.com/sourcegraph/sourcegraph-python/assets/18150705/559eef99-a897-4e7b-8167-9867aa4d62da)